### PR TITLE
fix(drivers): implement ResourceDriver.SensitiveKeys stub

### DIFF
--- a/drivers/acm.go
+++ b/drivers/acm.go
@@ -182,4 +182,7 @@ func acmCertToOutput(name string, cert *acmtypes.CertificateDetail) *interfaces.
 	}
 }
 
+// SensitiveKeys returns output keys whose values should be masked in logs and plan output.
+func (d *ACMDriver) SensitiveKeys() []string { return nil }
+
 var _ interfaces.ResourceDriver = (*ACMDriver)(nil)

--- a/drivers/alb.go
+++ b/drivers/alb.go
@@ -194,4 +194,7 @@ func albLBToOutput(lb *elbtypes.LoadBalancer) *interfaces.ResourceOutput {
 	}
 }
 
+// SensitiveKeys returns output keys whose values should be masked in logs and plan output.
+func (d *ALBDriver) SensitiveKeys() []string { return nil }
+
 var _ interfaces.ResourceDriver = (*ALBDriver)(nil)

--- a/drivers/apigateway.go
+++ b/drivers/apigateway.go
@@ -161,4 +161,7 @@ func apigwAPIToOutput(name string, apiID, endpoint *string, protocol string) *in
 	}
 }
 
+// SensitiveKeys returns output keys whose values should be masked in logs and plan output.
+func (d *APIGatewayDriver) SensitiveKeys() []string { return nil }
+
 var _ interfaces.ResourceDriver = (*APIGatewayDriver)(nil)

--- a/drivers/ecr.go
+++ b/drivers/ecr.go
@@ -129,4 +129,7 @@ func ecrRepoToOutput(repo *ecrtypes.Repository) *interfaces.ResourceOutput {
 	}
 }
 
+// SensitiveKeys returns output keys whose values should be masked in logs and plan output.
+func (d *ECRDriver) SensitiveKeys() []string { return nil }
+
 var _ interfaces.ResourceDriver = (*ECRDriver)(nil)

--- a/drivers/ecs.go
+++ b/drivers/ecs.go
@@ -247,4 +247,7 @@ func ecsServiceToOutput(name string, svc *ecstypes.Service) *interfaces.Resource
 	}
 }
 
+// SensitiveKeys returns output keys whose values should be masked in logs and plan output.
+func (d *ECSDriver) SensitiveKeys() []string { return nil }
+
 var _ interfaces.ResourceDriver = (*ECSDriver)(nil)

--- a/drivers/eks.go
+++ b/drivers/eks.go
@@ -151,4 +151,7 @@ func eksClusterToOutput(c *ekstypes.Cluster) *interfaces.ResourceOutput {
 	}
 }
 
+// SensitiveKeys returns output keys whose values should be masked in logs and plan output.
+func (d *EKSDriver) SensitiveKeys() []string { return nil }
+
 var _ interfaces.ResourceDriver = (*EKSDriver)(nil)

--- a/drivers/elasticache.go
+++ b/drivers/elasticache.go
@@ -173,4 +173,7 @@ func ecRGToOutput(rg *ectypes.ReplicationGroup) *interfaces.ResourceOutput {
 	}
 }
 
+// SensitiveKeys returns output keys whose values should be masked in logs and plan output.
+func (d *ElastiCacheDriver) SensitiveKeys() []string { return nil }
+
 var _ interfaces.ResourceDriver = (*ElastiCacheDriver)(nil)

--- a/drivers/iam.go
+++ b/drivers/iam.go
@@ -229,4 +229,7 @@ func defaultAssumeRolePolicy() string {
 	return string(data)
 }
 
+// SensitiveKeys returns output keys whose values should be masked in logs and plan output.
+func (d *IAMDriver) SensitiveKeys() []string { return nil }
+
 var _ interfaces.ResourceDriver = (*IAMDriver)(nil)

--- a/drivers/rds.go
+++ b/drivers/rds.go
@@ -200,4 +200,7 @@ func rdsDBToOutput(db *rdstypes.DBInstance) *interfaces.ResourceOutput {
 	}
 }
 
+// SensitiveKeys returns output keys whose values should be masked in logs and plan output.
+func (d *RDSDriver) SensitiveKeys() []string { return nil }
+
 var _ interfaces.ResourceDriver = (*RDSDriver)(nil)

--- a/drivers/route53.go
+++ b/drivers/route53.go
@@ -193,4 +193,7 @@ func r53ZoneToOutput(name string, zone *r53types.HostedZone) *interfaces.Resourc
 	}
 }
 
+// SensitiveKeys returns output keys whose values should be masked in logs and plan output.
+func (d *Route53Driver) SensitiveKeys() []string { return nil }
+
 var _ interfaces.ResourceDriver = (*Route53Driver)(nil)

--- a/drivers/s3.go
+++ b/drivers/s3.go
@@ -166,4 +166,7 @@ func s3BucketToOutput(name, region string) *interfaces.ResourceOutput {
 	}
 }
 
+// SensitiveKeys returns output keys whose values should be masked in logs and plan output.
+func (d *S3Driver) SensitiveKeys() []string { return nil }
+
 var _ interfaces.ResourceDriver = (*S3Driver)(nil)

--- a/drivers/sg.go
+++ b/drivers/sg.go
@@ -224,4 +224,7 @@ func sgToOutput(name, groupID, vpcID string) *interfaces.ResourceOutput {
 	}
 }
 
+// SensitiveKeys returns output keys whose values should be masked in logs and plan output.
+func (d *SecurityGroupDriver) SensitiveKeys() []string { return nil }
+
 var _ interfaces.ResourceDriver = (*SecurityGroupDriver)(nil)

--- a/drivers/vpc.go
+++ b/drivers/vpc.go
@@ -166,4 +166,7 @@ func vpcToOutput(name string, vpc *ec2types.Vpc) *interfaces.ResourceOutput {
 	}
 }
 
+// SensitiveKeys returns output keys whose values should be masked in logs and plan output.
+func (d *VPCDriver) SensitiveKeys() []string { return nil }
+
 var _ interfaces.ResourceDriver = (*VPCDriver)(nil)


### PR DESCRIPTION
## Summary

Adds the `SensitiveKeys() []string` method (returning `nil`) to all 13 `ResourceDriver` implementations in this plugin.

## Why

The `SensitiveKeys()` method was added to `interfaces.ResourceDriver` in `GoCodeAlone/workflow` on 2026-04-08 (commit `4853126`). This plugin's drivers never adopted the new method, leaving an interface-implementation gap that the pinned `workflow v0.3.56` masked. The gap is now surfaced by workflow PR #534's new cross-plugin-build CI gate, which compiles each plugin against current `workflow` main.

## What

13 driver types affected (one stub each):

- `ACMDriver`, `ALBDriver`, `APIGatewayDriver`, `ECRDriver`, `ECSDriver`, `EKSDriver`, `ElastiCacheDriver`, `IAMDriver`, `RDSDriver`, `Route53Driver`, `S3Driver`, `SecurityGroupDriver`, `VPCDriver`

Each gains:

```go
// SensitiveKeys returns output keys whose values should be masked in logs and plan output.
func (d *XDriver) SensitiveKeys() []string { return nil }
```

`nil` is the standard "no sensitive outputs" stub. Per-driver review of which output keys (if any) actually warrant masking is a follow-up activity outside this PR's scope.

## Test plan

- [x] `go build ./...` clean against pinned `workflow v0.3.56`
- [x] `go test ./...` passes (`drivers` + `provider` packages green)
- [x] Verified against `workflow v0.20.5` locally: all 13 `ResourceDriver` interface satisfaction errors disappear (a separate `IaCProvider.BootstrapStateBackend` gap remains, out of scope for this PR)

## Follow-ups

- `IaCProvider.BootstrapStateBackend` missing on `*AWSProvider` — separate interface-gap PR needed.
- Per-driver audit of whether any current `Outputs` keys merit a non-nil `SensitiveKeys` return.