### PR TITLE
ci: use releases token for engine lookup

### DIFF
--- a/.github/workflows/iac-host-conformance.yml
+++ b/.github/workflows/iac-host-conformance.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Determine Workflow engine versions
         id: versions
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASES_TOKEN || github.token }}
           WORKFLOW_CURRENT_VERSION: ${{ vars.WORKFLOW_CURRENT_VERSION }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- prefer RELEASES_TOKEN for cross-repo Workflow release lookup in IaC conformance
- fall back to github.token when the org secret is unavailable

## Verification
- actionlint .github/workflows/iac-host-conformance.yml