### PR TITLE
chore: sync plugin.json version to v1.2.0

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-aws",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "GoCodeAlone",
   "description": "AWS provider plugin for workflow IaC — manages ECS, EKS, RDS, ElastiCache, VPC, ALB, Route53, ECR, API Gateway, Security Groups, IAM, S3, ACM, and AutoScaling Group resources",
   "license": "MIT",


### PR DESCRIPTION
Manual sync — workflow-plugin-aws v1.2.0 tag push did not trigger sync-plugin-version.yml (GitHub Actions glitch; same workflow fired correctly on v1.1.0 from yesterday). One-line plugin.json version bump. Same outcome as auto-sync.

Releases asset state verified clean post-tag-push:
- v1.2.0 release: not draft, 7 assets (5 binaries + checksums + module zip)
- v1.2.0 is Latest

Follow-up issue to be filed to investigate the workflow non-trigger.