### PR TITLE
test(iac): pin ComputePlanVersion=v2 regression-guard; release v1.2.1

### DIFF
--- a/internal/iacserver_test.go
+++ b/internal/iacserver_test.go
@@ -97,3 +97,21 @@ func TestIaCServer_DetectDriftWithSpecs_DelegatesToDetectDrift(t *testing.T) {
 		t.Error("expected error from uninitialized provider")
 	}
 }
+
+// TestAWSIaCServer_Capabilities_ComputePlanVersionV2 pins the Phase 2
+// contract signal: the plugin MUST declare ComputePlanVersion="v2" so
+// wfctl routes via wfctlhelpers.ApplyPlanWithHooks (v2 dispatch).
+// A silent regression that drops the literal would degrade to v1
+// dispatch via wfctlhelpers.DispatchVersionFor's empty-default,
+// breaking the Phase 2 hard-cutover contract per ADR 0024 + ADR 0040.
+// Per workflow#640 + #695 Phase 2 + 2.5 cascade closeout.
+func TestAWSIaCServer_Capabilities_ComputePlanVersionV2(t *testing.T) {
+	s := NewIaCServer()
+	resp, err := s.Capabilities(context.Background(), &pb.CapabilitiesRequest{})
+	if err != nil {
+		t.Fatalf("Capabilities: %v", err)
+	}
+	if got := resp.GetComputePlanVersion(); got != "v2" {
+		t.Errorf("CapabilitiesResponse.ComputePlanVersion = %q; want %q (v2 dispatch opt-in lost)", got, "v2")
+	}
+}


### PR DESCRIPTION
## Summary

Per Phase 2 + 2.5 cascade closeout cleanup (Item 3 of `docs/plans/2026-05-17-phase2.5-cleanup-bundle-design.md` in workflow repo): adds the missing `Capabilities() → ComputePlanVersion="v2"` regression-guard test.

Without this, a future refactor of the `Capabilities` return literal could silently revert to v1 dispatch (empty ComputePlanVersion → wfctlhelpers.DispatchVersionFor empty-default) with no signal until production deploy fails.

Matches the equivalent test in workflow-plugin-gcp (`TestGCPIaCServer_Capabilities_ComputePlanVersionV2` at iacserver_test.go:67) and workflow-plugin-digitalocean (`TestDOIaCServer_Capabilities_DeclaresV2` at iacserver_finalize_test.go:192).

Test-only change; cuts as **v1.2.1 patch** (no behavioral impact).

## Test plan

- [x] `go test ./internal/ -run TestAWSIaCServer_Capabilities_ComputePlanVersionV2 -v` → PASS
- [x] `go test ./internal/ -race -count=1` → full package PASS race-clean

## Rollback

Revert commit. Test removal is non-functional.