### PR TITLE
workflow#699: drop AWSProvider.Apply (v2.0.0-rc1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0-rc1] — 2026-05-17
+
+### Breaking changes (workflow#699)
+
+- Removed `AWSProvider.Apply` Go method (dead since v1.2.0 v2 dispatch declaration; never reached by wfctl after v2 routes through `wfctlhelpers.ApplyPlanWithHooks`).
+- Removed `awsIaCServer.Apply` gRPC handler + `applyResultToPB` encoder helper. The proto-side `rpc Apply` was deleted in workflow v0.56.0-rc1.
+- Requires workflow v0.56.0+ (was v0.54.0).
+
+### Reason
+
+Per ADR 0024 compile-time-safety mandate: hard-delete the dead v1 Apply surface across the IaC plugin ecosystem. Plugin's typed `CapabilitiesResponse.compute_plan_version = "v2"` declaration unchanged.
+
 ## [1.1.0] — 2026-05-15
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoCodeAlone/workflow-plugin-aws
 go 1.26.0
 
 require (
-	github.com/GoCodeAlone/workflow v0.57.0-rc1
+	github.com/GoCodeAlone/workflow v0.57.0
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoCodeAlone/workflow-plugin-aws
 go 1.26.0
 
 require (
-	github.com/GoCodeAlone/workflow v0.54.0
+	github.com/GoCodeAlone/workflow v0.56.0-rc1
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoCodeAlone/workflow-plugin-aws
 go 1.26.0
 
 require (
-	github.com/GoCodeAlone/workflow v0.56.0-rc1
+	github.com/GoCodeAlone/workflow v0.57.0-rc1
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0 h1:cvdLHbM/vzvygQT
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0/go.mod h1:/9ipMG4qM2CHQ14BfXKdVlYRJelef6M8MFI5TbZv67M=
 github.com/GoCodeAlone/workflow v0.57.0-rc1 h1:HhRtsf70kDX0h72eWjl53qCB9p/6rvTLMUITCb7XPho=
 github.com/GoCodeAlone/workflow v0.57.0-rc1/go.mod h1:41J1BGZ+B0S6Ipjetu3UdGMo+Dkv0rc6lLmfooXFj7I=
+github.com/GoCodeAlone/workflow v0.57.0 h1:CHpJBxG4ubo1szJ9xHN2LogOkh3VPQPILwP6pXR4FSw=
+github.com/GoCodeAlone/workflow v0.57.0/go.mod h1:41J1BGZ+B0S6Ipjetu3UdGMo+Dkv0rc6lLmfooXFj7I=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=
 github.com/GoCodeAlone/yaegi v0.17.2/go.mod h1:z5Pr6Wse6QJcQvpgxTxzMAevFarH0N37TG88Y9dprx0=
 github.com/IBM/sarama v1.47.0 h1:GcQFEd12+KzfPYeLgN69Fh7vLCtYRhVIx0rO4TZO318=

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0 h1:xb1mI4NZkzvNKQ2F6nk
 github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0/go.mod h1:hhGouwAVsonmJ4Lain4jINZ9nZCoc9l9eF3BHbmR8eE=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0 h1:cvdLHbM/vzvygQTcAWSJsy+dAPzzwWyjzKMmTBFcFIo=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0/go.mod h1:/9ipMG4qM2CHQ14BfXKdVlYRJelef6M8MFI5TbZv67M=
-github.com/GoCodeAlone/workflow v0.56.0-rc1 h1:4lrJltcYDwhAY9L3YV7qNIUG/hHqqePZ9KlLJjqhXwo=
-github.com/GoCodeAlone/workflow v0.56.0-rc1/go.mod h1:41J1BGZ+B0S6Ipjetu3UdGMo+Dkv0rc6lLmfooXFj7I=
+github.com/GoCodeAlone/workflow v0.57.0-rc1 h1:HhRtsf70kDX0h72eWjl53qCB9p/6rvTLMUITCb7XPho=
+github.com/GoCodeAlone/workflow v0.57.0-rc1/go.mod h1:41J1BGZ+B0S6Ipjetu3UdGMo+Dkv0rc6lLmfooXFj7I=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=
 github.com/GoCodeAlone/yaegi v0.17.2/go.mod h1:z5Pr6Wse6QJcQvpgxTxzMAevFarH0N37TG88Y9dprx0=
 github.com/IBM/sarama v1.47.0 h1:GcQFEd12+KzfPYeLgN69Fh7vLCtYRhVIx0rO4TZO318=

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0 h1:xb1mI4NZkzvNKQ2F6nk
 github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0/go.mod h1:hhGouwAVsonmJ4Lain4jINZ9nZCoc9l9eF3BHbmR8eE=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0 h1:cvdLHbM/vzvygQTcAWSJsy+dAPzzwWyjzKMmTBFcFIo=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0/go.mod h1:/9ipMG4qM2CHQ14BfXKdVlYRJelef6M8MFI5TbZv67M=
-github.com/GoCodeAlone/workflow v0.54.0 h1:8x5iVQ8di2BAAyr/uAD/PllTa1Sw9OFElMkje0onKB8=
-github.com/GoCodeAlone/workflow v0.54.0/go.mod h1:RrmHdww6gAIUfyjJ7stz0fegxRmVGZvQ1FsuJ2F0C+U=
+github.com/GoCodeAlone/workflow v0.56.0-rc1 h1:4lrJltcYDwhAY9L3YV7qNIUG/hHqqePZ9KlLJjqhXwo=
+github.com/GoCodeAlone/workflow v0.56.0-rc1/go.mod h1:41J1BGZ+B0S6Ipjetu3UdGMo+Dkv0rc6lLmfooXFj7I=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=
 github.com/GoCodeAlone/yaegi v0.17.2/go.mod h1:z5Pr6Wse6QJcQvpgxTxzMAevFarH0N37TG88Y9dprx0=
 github.com/IBM/sarama v1.47.0 h1:GcQFEd12+KzfPYeLgN69Fh7vLCtYRhVIx0rO4TZO318=

--- a/internal/iacserver.go
+++ b/internal/iacserver.go
@@ -145,22 +145,6 @@ func (s *awsIaCServer) Plan(ctx context.Context, req *pb.PlanRequest) (*pb.PlanR
 	return &pb.PlanResponse{Plan: pbPlan}, nil
 }
 
-func (s *awsIaCServer) Apply(ctx context.Context, req *pb.ApplyRequest) (*pb.ApplyResponse, error) {
-	plan, err := planFromPB(req.GetPlan())
-	if err != nil {
-		return nil, fmt.Errorf("aws iacserver: decode Apply plan: %w", err)
-	}
-	result, err := s.provider.Apply(ctx, plan)
-	if err != nil {
-		return nil, err
-	}
-	pbResult, err := applyResultToPB(result)
-	if err != nil {
-		return nil, fmt.Errorf("aws iacserver: encode Apply response: %w", err)
-	}
-	return &pb.ApplyResponse{Result: pbResult}, nil
-}
-
 func (s *awsIaCServer) Destroy(ctx context.Context, req *pb.DestroyRequest) (*pb.DestroyResponse, error) {
 	refs := refsFromPB(req.GetRefs())
 	result, err := s.provider.Destroy(ctx, refs)
@@ -673,42 +657,6 @@ func planFromPB(p *pb.IaCPlan) (*interfaces.IaCPlan, error) {
 		DesiredHash:   p.GetDesiredHash(),
 		SchemaVersion: int(p.GetSchemaVersion()),
 		InputSnapshot: copyStringMap(p.GetInputSnapshot()),
-	}, nil
-}
-
-func applyResultToPB(r *interfaces.ApplyResult) (*pb.ApplyResult, error) {
-	if r == nil {
-		return nil, nil
-	}
-	resources := make([]*pb.ResourceOutput, 0, len(r.Resources))
-	for i := range r.Resources {
-		ro, err := outputToPB(&r.Resources[i])
-		if err != nil {
-			return nil, err
-		}
-		if ro != nil {
-			resources = append(resources, ro)
-		}
-	}
-	errs := make([]*pb.ActionError, 0, len(r.Errors))
-	for _, e := range r.Errors {
-		errs = append(errs, &pb.ActionError{Resource: e.Resource, Action: e.Action, Error: e.Error})
-	}
-	driftReport := make([]*pb.DriftEntry, 0, len(r.InputDriftReport))
-	for _, d := range r.InputDriftReport {
-		driftReport = append(driftReport, &pb.DriftEntry{
-			Name:             d.Name,
-			PlanFingerprint:  d.PlanFingerprint,
-			ApplyFingerprint: d.ApplyFingerprint,
-		})
-	}
-	return &pb.ApplyResult{
-		PlanId:               r.PlanID,
-		Resources:            resources,
-		Errors:               errs,
-		InitialInputSnapshot: copyStringMap(r.InitialInputSnapshot),
-		InputDriftReport:     driftReport,
-		ReplaceIdMap:         copyStringMap(r.ReplaceIDMap),
 	}, nil
 }
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "workflow-plugin-aws",
-  "version": "1.2.1",
+  "version": "2.0.0-rc1",
   "author": "GoCodeAlone",
   "description": "AWS provider plugin for workflow IaC \u2014 manages ECS, EKS, RDS, ElastiCache, VPC, ALB, Route53, ECR, API Gateway, Security Groups, IAM, S3, ACM, and AutoScaling Group resources",
   "license": "MIT",
   "type": "external",
   "tier": "community",
-  "minEngineVersion": "0.54.0",
+  "minEngineVersion": "0.56.0",
   "keywords": [
     "aws",
     "iac",

--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "external",
   "tier": "community",
-  "minEngineVersion": "0.56.0-rc1",
+  "minEngineVersion": "0.57.0-rc1",
   "keywords": [
     "aws",
     "iac",

--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "external",
   "tier": "community",
-  "minEngineVersion": "0.56.0",
+  "minEngineVersion": "0.56.0-rc1",
   "keywords": [
     "aws",
     "iac",
@@ -39,32 +39,32 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v1.1.0/workflow-plugin-aws_1.1.0_linux_amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.0.0-rc1/workflow-plugin-aws_2.0.0-rc1_linux_amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v1.1.0/workflow-plugin-aws_1.1.0_linux_arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.0.0-rc1/workflow-plugin-aws_2.0.0-rc1_linux_arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v1.1.0/workflow-plugin-aws_1.1.0_darwin_amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.0.0-rc1/workflow-plugin-aws_2.0.0-rc1_darwin_amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v1.1.0/workflow-plugin-aws_1.1.0_darwin_arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.0.0-rc1/workflow-plugin-aws_2.0.0-rc1_darwin_arm64.tar.gz"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v1.1.0/workflow-plugin-aws_1.1.0_windows_amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.0.0-rc1/workflow-plugin-aws_2.0.0-rc1_windows_amd64.tar.gz"
     },
     {
       "os": "windows",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v1.1.0/workflow-plugin-aws_1.1.0_windows_arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.0.0-rc1/workflow-plugin-aws_2.0.0-rc1_windows_arm64.tar.gz"
     }
   ]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "workflow-plugin-aws",
-  "version": "2.0.0-rc1",
+  "version": "2.0.0",
   "author": "GoCodeAlone",
   "description": "AWS provider plugin for workflow IaC \u2014 manages ECS, EKS, RDS, ElastiCache, VPC, ALB, Route53, ECR, API Gateway, Security Groups, IAM, S3, ACM, and AutoScaling Group resources",
   "license": "MIT",
   "type": "external",
   "tier": "community",
-  "minEngineVersion": "0.57.0-rc1",
+  "minEngineVersion": "0.57.0",
   "keywords": [
     "aws",
     "iac",
@@ -39,32 +39,32 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.0.0-rc1/workflow-plugin-aws_2.0.0-rc1_linux_amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.0.0/workflow-plugin-aws_2.0.0_linux_amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.0.0-rc1/workflow-plugin-aws_2.0.0-rc1_linux_arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.0.0/workflow-plugin-aws_2.0.0_linux_arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.0.0-rc1/workflow-plugin-aws_2.0.0-rc1_darwin_amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.0.0/workflow-plugin-aws_2.0.0_darwin_amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.0.0-rc1/workflow-plugin-aws_2.0.0-rc1_darwin_arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.0.0/workflow-plugin-aws_2.0.0_darwin_arm64.tar.gz"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.0.0-rc1/workflow-plugin-aws_2.0.0-rc1_windows_amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.0.0/workflow-plugin-aws_2.0.0_windows_amd64.tar.gz"
     },
     {
       "os": "windows",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.0.0-rc1/workflow-plugin-aws_2.0.0-rc1_windows_arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v2.0.0/workflow-plugin-aws_2.0.0_windows_arm64.tar.gz"
     }
   ]
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -233,61 +233,6 @@ func (p *AWSProvider) Plan(ctx context.Context, desired []interfaces.ResourceSpe
 	return plan, nil
 }
 
-// Apply executes the plan actions.
-func (p *AWSProvider) Apply(ctx context.Context, plan *interfaces.IaCPlan) (*interfaces.ApplyResult, error) {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	if !p.initialized {
-		return nil, fmt.Errorf("aws: provider not initialized")
-	}
-
-	result := &interfaces.ApplyResult{PlanID: plan.ID}
-
-	for _, action := range plan.Actions {
-		drv, err := p.resourceDriver(action.Resource.Type)
-		if err != nil {
-			result.Errors = append(result.Errors, interfaces.ActionError{
-				Resource: action.Resource.Name,
-				Action:   action.Action,
-				Error:    err.Error(),
-			})
-			continue
-		}
-
-		var out *interfaces.ResourceOutput
-		switch action.Action {
-		case "create":
-			out, err = drv.Create(ctx, action.Resource)
-		case "update", "replace":
-			ref := interfaces.ResourceRef{Name: action.Resource.Name, Type: action.Resource.Type}
-			if action.Current != nil {
-				ref.ProviderID = action.Current.ProviderID
-			}
-			out, err = drv.Update(ctx, ref, action.Resource)
-		case "delete":
-			ref := interfaces.ResourceRef{Name: action.Resource.Name, Type: action.Resource.Type}
-			if action.Current != nil {
-				ref.ProviderID = action.Current.ProviderID
-			}
-			err = drv.Delete(ctx, ref)
-		}
-
-		if err != nil {
-			result.Errors = append(result.Errors, interfaces.ActionError{
-				Resource: action.Resource.Name,
-				Action:   action.Action,
-				Error:    err.Error(),
-			})
-			continue
-		}
-		if out != nil {
-			result.Resources = append(result.Resources, *out)
-		}
-	}
-
-	return result, nil
-}
-
 // Destroy deletes a set of resources.
 func (p *AWSProvider) Destroy(ctx context.Context, resources []interfaces.ResourceRef) (*interfaces.DestroyResult, error) {
 	p.mu.RLock()


### PR DESCRIPTION
Requires workflow v0.56.0-rc1+. Drops dead v1 Apply surface per ADR 0024.

## Summary
- Delete AWSProvider.Apply (dead since v1.2.0 v2 declaration)
- Delete awsIaCServer.Apply RPC handler + applyResultToPB
- Bump SDK pin v0.54.0 → v0.56.0-rc1; plugin v1.2.1 → v2.0.0-rc1; minEngine 0.54.0 → 0.56.0

See workflow#699 for cascade context.