### PR TITLE
docs(aws): add README + examples + experimental banner (QoL sweep)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Report a bug in this plugin
+title: '[Bug] '
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## To reproduce
+
+Steps to reproduce the behavior:
+1. Config used (redact any secrets)
+2. Command run
+3. Error output
+
+## Expected behavior
+
+What you expected to happen.
+
+## Environment
+
+- workflow engine version: <!-- e.g. 0.3.51 -->
+- plugin version: <!-- e.g. 1.0.0 -->
+- Go version: <!-- go version -->
+- OS: <!-- e.g. linux/amd64, darwin/arm64 -->
+
+## Additional context
+
+Add any other context or logs here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest a new capability for this plugin
+title: '[Feature] '
+labels: enhancement
+assignees: ''
+---
+
+## Summary
+
+A one-sentence description of the feature.
+
+## Motivation
+
+Why is this feature needed? What problem does it solve?
+
+## Proposed solution
+
+How would you like it to work? Include config schema changes if relevant.
+
+## Alternatives considered
+
+Any alternative approaches you considered and why you ruled them out.
+
+## Additional context
+
+Links, screenshots, or related issues.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- What does this PR do? 1-3 bullet points. -->
+
+## Motivation
+
+<!-- Why is this change needed? Link to issue if applicable. Closes #NNN -->
+
+## Test plan
+
+- [ ] `go build ./...` passes
+- [ ] `go vet ./...` passes
+- [ ] `go test ./...` passes
+- [ ] Manual smoke test (describe)
+
+## Checklist
+
+- [ ] CHANGELOG.md updated (Keep-a-Changelog format)
+- [ ] No secrets or credentials included
+- [ ] One feature or bugfix per PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing to workflow-plugin-aws
+
+This plugin is part of the [GoCodeAlone/workflow](https://github.com/GoCodeAlone/workflow) ecosystem.
+
+## Before contributing
+
+Read the [upstream CONTRIBUTING.md](https://github.com/GoCodeAlone/workflow/blob/main/CONTRIBUTING.md) for general conventions, signing, and review expectations.
+
+## Local development
+
+```sh
+git clone https://github.com/GoCodeAlone/workflow-plugin-aws.git
+cd workflow-plugin-aws
+go build ./...
+go test ./...
+```
+
+## Pull requests
+
+- One feature or bugfix per PR.
+- Update CHANGELOG.md with a Keep-a-Changelog entry.
+- Add tests covering new behavior.
+- Run `go vet ./...` before pushing.
+
+## Reporting issues
+
+See the issue templates under `.github/ISSUE_TEMPLATE/`.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ AWS provider plugin for workflow IaC — manages ECS, EKS, RDS, ElastiCache, VPC
 version: 1
 plugins:
   - name: workflow-plugin-aws
-    version: v2.0.0
+    version: v1.2.1
     source: github.com/GoCodeAlone/workflow-plugin-aws
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,62 @@
+# workflow-plugin-aws
+
+> ⚠️ **Experimental** — This plugin compiles and passes its unit tests but has not been validated in any active GoCodeAlone-internal production deployment. Use with caution. Please [open an issue](https://github.com/GoCodeAlone/workflow-plugin-aws/issues/new) if you adopt it so we can promote it to **verified** status.
+
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Go Reference](https://pkg.go.dev/badge/github.com/GoCodeAlone/workflow-plugin-aws.svg)](https://pkg.go.dev/github.com/GoCodeAlone/workflow-plugin-aws)
+
+AWS provider plugin for workflow IaC — manages ECS, EKS, RDS, ElastiCache, VPC, ALB, Route53, ECR, API Gateway, Security Groups, IAM, S3, ACM, and AutoScaling Group resources.
+
+## What it provides
+
+**Module types:**
+- `iac.provider` — AWS IaC provider (v2 compute-plan dispatch)
+- `aws.credentials` — AWS credential configuration module
+- `storage.s3` — S3 storage backend module
+
+**Pipeline step types:**
+- `step.s3_upload` — Upload files to S3 from a pipeline step
+
+**IaC state backends:**
+- `s3` — Remote state stored in S3
+
+## Install
+
+```yaml
+# In your wfctl.yaml
+version: 1
+plugins:
+  - name: workflow-plugin-aws
+    version: 2.0.0
+    source: github.com/GoCodeAlone/workflow-plugin-aws
+```
+
+Then:
+
+```sh
+wfctl plugin install
+```
+
+## Minimal example
+
+See [`examples/minimal/config.yaml`](examples/minimal/config.yaml).
+
+**Required environment variables:**
+
+| Variable | Description |
+|----------|-------------|
+| `AWS_REGION` | AWS region (e.g. `us-east-1`) |
+| `AWS_ACCESS_KEY_ID` | AWS access key ID |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret access key |
+
+Alternatively, configure an IAM role on the host (the plugin respects the standard AWS credential chain).
+
+## Documentation
+
+- [Plugin authoring guide (upstream)](https://github.com/GoCodeAlone/workflow/blob/main/docs/PLUGIN_AUTHORING.md)
+- [Workflow engine docs](https://github.com/GoCodeAlone/workflow)
+- [IaC guide](https://github.com/GoCodeAlone/workflow/blob/main/docs/iac/)
+
+## License
+
+MIT. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ AWS provider plugin for workflow IaC — manages ECS, EKS, RDS, ElastiCache, VPC
 version: 1
 plugins:
   - name: workflow-plugin-aws
-    version: 2.0.0
+    version: v2.0.0
     source: github.com/GoCodeAlone/workflow-plugin-aws
 ```
 

--- a/examples/minimal/config.yaml
+++ b/examples/minimal/config.yaml
@@ -1,0 +1,32 @@
+# workflow-plugin-aws minimal example
+# Demonstrates AWS IaC provider configuration.
+# Validate with: wfctl validate --skip-unknown-types examples/minimal/config.yaml
+#
+# Required env vars: AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+
+modules:
+  - name: aws-credentials
+    type: aws.credentials
+    config:
+      region: "${AWS_REGION}"
+      access_key_id: "${AWS_ACCESS_KEY_ID}"
+      secret_access_key: "${AWS_SECRET_ACCESS_KEY}"
+
+  - name: aws-provider
+    type: iac.provider
+    config:
+      provider: aws
+      credentials_module: aws-credentials
+
+workflows:
+  pipeline:
+    trigger:
+      type: http
+      config:
+        path: /deploy
+        method: POST
+    steps:
+      - name: deploy
+        type: step.log
+        config:
+          message: "AWS IaC provider ready. Use wfctl iac apply to provision resources."


### PR DESCRIPTION
## Summary

- Authors `README.md` from scratch with experimental status banner, module/step/backend capabilities, install instructions, and required env var table
- Adds `examples/minimal/config.yaml` — validated with `wfctl validate --skip-unknown-types` ✅
- Adds `CONTRIBUTING.md` from shared plugin template
- Adds `.github/` issue templates (bug report, feature request) and PR template

## Test plan

- [x] `GOWORK=off go build ./...` passes
- [x] `GOWORK=off go vet ./...` passes
- [x] `wfctl validate --skip-unknown-types examples/minimal/config.yaml` passes

## Related

Part of the 2026-05-19 multi-repo OSS-readiness QoL sweep.
See: GoCodeAlone/workflow#714

🤖 Generated with [Claude Code](https://claude.com/claude-code)