### PR TITLE
docs(aws): prefix CONTRIBUTING commands with GOWORK=off

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,8 @@ Read the [upstream CONTRIBUTING.md](https://github.com/GoCodeAlone/workflow/blob
 ```sh
 git clone https://github.com/GoCodeAlone/workflow-plugin-aws.git
 cd workflow-plugin-aws
-go build ./...
-go test ./...
+GOWORK=off go build ./...
+GOWORK=off go test ./...
 ```
 
 ## Pull requests
@@ -20,7 +20,7 @@ go test ./...
 - One feature or bugfix per PR.
 - Update CHANGELOG.md with a Keep-a-Changelog entry.
 - Add tests covering new behavior.
-- Run `go vet ./...` before pushing.
+- Run `GOWORK=off go vet ./...` before pushing.
 
 ## Reporting issues
 


### PR DESCRIPTION
Follow-up to workflow#721 (upstream template).