### PR TITLE
ci: wire wfctl plugin verify-capabilities + bump wfctl pin to v0.63.1 (workflow#765)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # workflow#765: runtime truth-check via plugin verify-capabilities.
+      - name: Verify capabilities (runtime truth-check)
+        run: |
+          RUNNER_ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          BIN=$(jq -r --arg arch "$RUNNER_ARCH" \
+            '[.[] | select(.type=="Binary" and .goos=="linux" and .goarch==$arch and (.name|startswith("workflow-plugin-aws")))] | .[0].path // ""' \
+            dist/artifacts.json)
+          if [ -z "$BIN" ] || [ "$BIN" = "null" ]; then
+            echo "::warning::No matching linux/$RUNNER_ARCH binary in dist/artifacts.json; skipping verify-capabilities"
+            jq '.[] | {name, type, goos, goarch, path}' dist/artifacts.json
+            exit 0
+          fi
+          "${{ runner.temp }}/wfctl-bin/wfctl" plugin verify-capabilities --binary "$BIN" .
       - name: Verify shipped plugin.json carries tag (post-build)
         run: |
           if [ -f .release/plugin.json ]; then


### PR DESCRIPTION
Layer 3b extension from workflow#765 sweep. Adds post-goreleaser `wfctl plugin verify-capabilities` step to release.yml; bumps Install wfctl pin v0.62.0 → v0.63.1 (carries the new subcommand). jq filter selects this plugin's linux/<runner-arch> binary from `dist/artifacts.json`; skip-with-warning if no match.

Closes the runtime truth-loop on releases: validate-contract (static) + verify-capabilities (runtime) confirm both the source-tree shape AND the actual built binary's GetManifest match plugin.json.