### PR TITLE
feat(plugin): declare iacServices in plugin.json; bump workflow v0.64.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: GoCodeAlone/setup-wfctl@v1
         with:
-          version: v0.63.2
+          version: v0.64.0
 
       - name: Validate plugin contract for publish (pre-build)
         run: wfctl plugin validate-contract --for-publish --tag "${{ github.ref_name }}" .

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoCodeAlone/workflow-plugin-aws
 go 1.26.0
 
 require (
-	github.com/GoCodeAlone/workflow v0.61.0
+	github.com/GoCodeAlone/workflow v0.64.0
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0 h1:xb1mI4NZkzvNKQ2F6nk
 github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0/go.mod h1:hhGouwAVsonmJ4Lain4jINZ9nZCoc9l9eF3BHbmR8eE=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0 h1:cvdLHbM/vzvygQTcAWSJsy+dAPzzwWyjzKMmTBFcFIo=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0/go.mod h1:/9ipMG4qM2CHQ14BfXKdVlYRJelef6M8MFI5TbZv67M=
-github.com/GoCodeAlone/workflow v0.61.0 h1:uBonpAqU04+vdAQMUs/5ZTCJJpuTOBl4sSSILjd9xag=
-github.com/GoCodeAlone/workflow v0.61.0/go.mod h1:659GGDrw3QJ7b625y9rf8QhKIpt1VCoEG0MxKu5tGQs=
+github.com/GoCodeAlone/workflow v0.64.0 h1:2CpbYPwIqdGDb3xi3YJpwcteIum4ehBSrnRql/1YvB4=
+github.com/GoCodeAlone/workflow v0.64.0/go.mod h1:659GGDrw3QJ7b625y9rf8QhKIpt1VCoEG0MxKu5tGQs=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=
 github.com/GoCodeAlone/yaegi v0.17.2/go.mod h1:z5Pr6Wse6QJcQvpgxTxzMAevFarH0N37TG88Y9dprx0=
 github.com/IBM/sarama v1.47.0 h1:GcQFEd12+KzfPYeLgN69Fh7vLCtYRhVIx0rO4TZO318=

--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,17 @@
   "license": "MIT",
   "type": "external",
   "tier": "community",
-  "minEngineVersion": "0.61.0",
+  "minEngineVersion": "0.64.0",
+  "iacServices": [
+    "workflow.plugin.external.iac.IaCProviderRequired",
+    "workflow.plugin.external.iac.IaCProviderEnumerator",
+    "workflow.plugin.external.iac.IaCProviderDriftDetector",
+    "workflow.plugin.external.iac.IaCProviderCredentialRevoker",
+    "workflow.plugin.external.iac.IaCProviderMigrationRepairer",
+    "workflow.plugin.external.iac.IaCProviderValidator",
+    "workflow.plugin.external.iac.IaCProviderDriftConfigDetector",
+    "workflow.plugin.external.iac.IaCStateBackend"
+  ],
   "keywords": [
     "aws",
     "iac",


### PR DESCRIPTION
## Summary

Declares the 8 IaC gRPC services this plugin registers via `sdk.ServeIaCPlugin`, using the new `iacServices` manifest field added in [workflow#767](https://github.com/GoCodeAlone/workflow/pull/773) (v0.64.0). Enables `wfctl plugin verify-capabilities` contract-diff to catch service-registration drift between this plugin's `plugin.json` and its runtime gRPC surface.

## Changes

- `plugin.json`: adds `iacServices` array (8 services) + bumps `minEngineVersion` 0.61.0 → 0.64.0
- `go.mod`: bumps `github.com/GoCodeAlone/workflow` 0.61.0 → 0.64.0
- `.github/workflows/release.yml`: bumps `setup-wfctl@v1` pinned version 0.63.2 → 0.64.0

## Test Plan

- [x] `GOWORK=off go build ./...` exit 0
- [x] `GOWORK=off go test ./...` all PASS
- [x] Manifest content matches `internal/iacserver.go` Unimplemented embeds
- [x] `release.yml` setup-wfctl version reflects v0.64.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)