### PR TITLE
ci: modernize action pins and Go baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,13 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 'stable'
+          go-version-file: go.mod
+          cache: false
 
       - name: Download dependencies
         run: go mod download
@@ -36,12 +37,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Validate strict plugin contracts
-        run: go run github.com/GoCodeAlone/workflow/cmd/wfctl@v0.64.3 plugin validate --file plugin.json --strict-contracts
+        run: go run github.com/GoCodeAlone/workflow/cmd/wfctl@v0.74.6 plugin validate --file plugin.json --strict-contracts

--- a/.github/workflows/iac-host-conformance.yml
+++ b/.github/workflows/iac-host-conformance.yml
@@ -14,11 +14,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Configure Git for private repos
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,24 +14,40 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          cache: false
 
-      - uses: GoCodeAlone/setup-wfctl@v1
-        with:
-          version: v0.64.3
+      - name: Install wfctl v0.74.6
+        env:
+          GH_TOKEN: ${{ secrets.RELEASES_TOKEN || github.token }}
+          WFCTL_VERSION: v0.74.6
+        run: |
+          set -euo pipefail
+          runner_arch=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          asset="wfctl-linux-${runner_arch}"
+          download_dir="$(mktemp -d)"
+          gh release download "${WFCTL_VERSION}" \
+            --repo GoCodeAlone/workflow \
+            --pattern "${asset}" \
+            --pattern checksums.txt \
+            --dir "${download_dir}"
+          (cd "${download_dir}" && grep "  ${asset}$" checksums.txt | sha256sum -c -)
+          mkdir -p "${RUNNER_TEMP}/wfctl-bin"
+          install -m 0755 "${download_dir}/${asset}" "${RUNNER_TEMP}/wfctl-bin/wfctl"
+          echo "${RUNNER_TEMP}/wfctl-bin" >> "$GITHUB_PATH"
 
       - name: Validate plugin contract for publish (pre-build)
         run: wfctl plugin validate-contract --for-publish --tag "${{ github.ref_name }}" .
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser
           version: '~> v2'
@@ -78,7 +94,7 @@ jobs:
       && github.repository == 'GoCodeAlone/workflow-plugin-aws'
     steps:
       - name: Trigger registry manifest sync
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.repo_dispatch_token }}
           repository: GoCodeAlone/workflow-registry

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoCodeAlone/workflow-plugin-aws
 
-go 1.26.0
+go 1.26.4
 
 require (
 	github.com/GoCodeAlone/workflow v0.73.0
@@ -11,6 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.33.8
 	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.16
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.55.2
+	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.74.4
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.296.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.44.2
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.76.0
@@ -50,7 +51,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.27 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.27 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.23 // indirect
-	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.74.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.12 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.22 // indirect


### PR DESCRIPTION
## Summary
- pin CI, release, and IaC conformance workflows to audited action SHAs with version comments
- bump the module Go directive to 1.26.4
- use wfctl v0.74.6 for contract validation, with release install checksum verification

## Verification
- actionlint .github/workflows/*.yml
- GOWORK=off go test ./...
