### PR TITLE
chore: declare secret target support

### DIFF
--- a/cmd/workflow-plugin-aws/plugin.json
+++ b/cmd/workflow-plugin-aws/plugin.json
@@ -7,6 +7,20 @@
   "type": "external",
   "tier": "community",
   "minEngineVersion": "0.73.0",
+  "required_secrets": [
+    {
+      "name": "AWS_ACCESS_KEY_ID",
+      "sensitive": true,
+      "description": "AWS access key ID. For credentials.type: env or static; profile/role_arn deployments may skip. Referenced as ${AWS_ACCESS_KEY_ID} in the iac.provider/aws config.",
+      "prompt": "AWS access key ID"
+    },
+    {
+      "name": "AWS_SECRET_ACCESS_KEY",
+      "sensitive": true,
+      "description": "AWS secret access key (pairs with AWS_ACCESS_KEY_ID). Referenced as ${AWS_SECRET_ACCESS_KEY}.",
+      "prompt": "AWS secret access key"
+    }
+  ],
   "iacServices": [
     "workflow.plugin.external.iac.IaCProviderRequired",
     "workflow.plugin.external.iac.IaCProviderEnumerator",
@@ -81,5 +95,53 @@
       "arch": "arm64",
       "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v0.0.0/workflow-plugin-aws-windows-arm64.tar.gz"
     }
-  ]
+  ],
+    "secret_targets": [
+      {
+        "provider": "github",
+        "scopes": [
+          "repo",
+          "env",
+          "org"
+        ],
+        "description": "Stored as GitHub Actions secrets when workflows run on GitHub."
+      },
+      {
+        "provider": "gitlab",
+        "scopes": [
+          "project",
+          "group",
+          "env"
+        ],
+        "description": "Stored as GitLab CI/CD variables when workflows run on GitLab."
+      },
+      {
+        "provider": "vault",
+        "scopes": [
+          "mount"
+        ],
+        "description": "Stored in Vault for application/runtime retrieval."
+      },
+      {
+        "provider": "file",
+        "scopes": [
+          "directory"
+        ],
+        "description": "Stored in a local file-backed secret store."
+      },
+      {
+        "provider": "keychain",
+        "scopes": [
+          "service"
+        ],
+        "description": "Stored in the local OS keychain."
+      },
+      {
+        "provider": "env",
+        "scopes": [
+          "process"
+        ],
+        "description": "Provided by the local process environment."
+      }
+    ]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -95,5 +95,53 @@
       "arch": "arm64",
       "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v0.0.0/workflow-plugin-aws-windows-arm64.tar.gz"
     }
+  ],
+  "secret_targets": [
+    {
+      "provider": "github",
+      "scopes": [
+        "repo",
+        "env",
+        "org"
+      ],
+      "description": "Stored as GitHub Actions secrets when workflows run on GitHub."
+    },
+    {
+      "provider": "gitlab",
+      "scopes": [
+        "project",
+        "group",
+        "env"
+      ],
+      "description": "Stored as GitLab CI/CD variables when workflows run on GitLab."
+    },
+    {
+      "provider": "vault",
+      "scopes": [
+        "mount"
+      ],
+      "description": "Stored in Vault for application/runtime retrieval."
+    },
+    {
+      "provider": "file",
+      "scopes": [
+        "directory"
+      ],
+      "description": "Stored in a local file-backed secret store."
+    },
+    {
+      "provider": "keychain",
+      "scopes": [
+        "service"
+      ],
+      "description": "Stored in the local OS keychain."
+    },
+    {
+      "provider": "env",
+      "scopes": [
+        "process"
+      ],
+      "description": "Provided by the local process environment."
+    }
   ]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -96,52 +96,52 @@
       "url": "https://github.com/GoCodeAlone/workflow-plugin-aws/releases/download/v0.0.0/workflow-plugin-aws-windows-arm64.tar.gz"
     }
   ],
-  "secret_targets": [
-    {
-      "provider": "github",
-      "scopes": [
-        "repo",
-        "env",
-        "org"
-      ],
-      "description": "Stored as GitHub Actions secrets when workflows run on GitHub."
-    },
-    {
-      "provider": "gitlab",
-      "scopes": [
-        "project",
-        "group",
-        "env"
-      ],
-      "description": "Stored as GitLab CI/CD variables when workflows run on GitLab."
-    },
-    {
-      "provider": "vault",
-      "scopes": [
-        "mount"
-      ],
-      "description": "Stored in Vault for application/runtime retrieval."
-    },
-    {
-      "provider": "file",
-      "scopes": [
-        "directory"
-      ],
-      "description": "Stored in a local file-backed secret store."
-    },
-    {
-      "provider": "keychain",
-      "scopes": [
-        "service"
-      ],
-      "description": "Stored in the local OS keychain."
-    },
-    {
-      "provider": "env",
-      "scopes": [
-        "process"
-      ],
-      "description": "Provided by the local process environment."
-    }
-  ]
+    "secret_targets": [
+      {
+        "provider": "github",
+        "scopes": [
+          "repo",
+          "env",
+          "org"
+        ],
+        "description": "Stored as GitHub Actions secrets when workflows run on GitHub."
+      },
+      {
+        "provider": "gitlab",
+        "scopes": [
+          "project",
+          "group",
+          "env"
+        ],
+        "description": "Stored as GitLab CI/CD variables when workflows run on GitLab."
+      },
+      {
+        "provider": "vault",
+        "scopes": [
+          "mount"
+        ],
+        "description": "Stored in Vault for application/runtime retrieval."
+      },
+      {
+        "provider": "file",
+        "scopes": [
+          "directory"
+        ],
+        "description": "Stored in a local file-backed secret store."
+      },
+      {
+        "provider": "keychain",
+        "scopes": [
+          "service"
+        ],
+        "description": "Stored in the local OS keychain."
+      },
+      {
+        "provider": "env",
+        "scopes": [
+          "process"
+        ],
+        "description": "Provided by the local process environment."
+      }
+    ]
 }


### PR DESCRIPTION
## Summary
- declare supported `secret_targets[]` for plugin required secrets
- include GitHub Actions, GitLab CI/CD variables, Vault, file, keychain, and explicit local env targets

## Verification
- `jq empty plugin.json`
- `git diff --check`
