### PR TITLE
fix: classify AWS env setup values

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ wfctl plugin install
 
 See [`examples/minimal/config.yaml`](examples/minimal/config.yaml).
 
-**Required environment variables:**
+**Required environment values:**
 
-| Variable | Description |
-|----------|-------------|
-| `AWS_REGION` | AWS region (e.g. `us-east-1`) |
-| `AWS_ACCESS_KEY_ID` | AWS access key ID |
-| `AWS_SECRET_ACCESS_KEY` | AWS secret access key |
+| Variable | Kind | Description |
+|----------|------|-------------|
+| `AWS_REGION` | var | AWS region (e.g. `us-east-1`) |
+| `AWS_ACCESS_KEY_ID` | var | AWS access key ID |
+| `AWS_SECRET_ACCESS_KEY` | secret | AWS secret access key |
 
 Alternatively, configure an IAM role on the host (the plugin respects the standard AWS credential chain).
 

--- a/cmd/workflow-plugin-aws/plugin.json
+++ b/cmd/workflow-plugin-aws/plugin.json
@@ -9,16 +9,26 @@
   "minEngineVersion": "0.73.0",
   "required_secrets": [
     {
-      "name": "AWS_ACCESS_KEY_ID",
-      "sensitive": true,
-      "description": "AWS access key ID. For credentials.type: env or static; profile/role_arn deployments may skip. Referenced as ${AWS_ACCESS_KEY_ID} in the iac.provider/aws config.",
-      "prompt": "AWS access key ID"
-    },
-    {
       "name": "AWS_SECRET_ACCESS_KEY",
       "sensitive": true,
       "description": "AWS secret access key (pairs with AWS_ACCESS_KEY_ID). Referenced as ${AWS_SECRET_ACCESS_KEY}.",
       "prompt": "AWS secret access key"
+    }
+  ],
+  "required_config": [
+    {
+      "name": "AWS_REGION",
+      "key": "region",
+      "sensitive": false,
+      "description": "AWS region for provider operations and config templates. Referenced as ${AWS_REGION}.",
+      "prompt": "AWS region"
+    },
+    {
+      "name": "AWS_ACCESS_KEY_ID",
+      "key": "access_key_id",
+      "sensitive": false,
+      "description": "AWS access key ID. For credentials.type: env or static; profile/role_arn deployments may skip. Referenced as ${AWS_ACCESS_KEY_ID}.",
+      "prompt": "AWS access key ID"
     }
   ],
   "iacServices": [
@@ -110,10 +120,9 @@
         "provider": "gitlab",
         "scopes": [
           "project",
-          "group",
-          "env"
+          "group"
         ],
-        "description": "Stored as GitLab CI/CD variables when workflows run on GitLab."
+        "description": "Stored as GitLab CI/CD variables when workflows run on GitLab; variables may also be narrowed with GitLab environment_scope."
       },
       {
         "provider": "vault",
@@ -143,5 +152,38 @@
         ],
         "description": "Provided by the local process environment."
       }
-    ]
+    ],
+  "config_targets": [
+    {
+      "provider": "github",
+      "scopes": [
+        "repo",
+        "env",
+        "org"
+      ],
+      "description": "Stored as GitHub Actions variables when workflows run on GitHub."
+    },
+    {
+      "provider": "gitlab",
+      "scopes": [
+        "project",
+        "group"
+      ],
+      "description": "Stored as GitLab CI/CD variables when workflows run on GitLab; variables may also be narrowed with GitLab environment_scope."
+    },
+    {
+      "provider": "file",
+      "scopes": [
+        "directory"
+      ],
+      "description": "Stored in a local dotenv/config file for local workflows."
+    },
+    {
+      "provider": "env",
+      "scopes": [
+        "process"
+      ],
+      "description": "Provided by the local process environment."
+    }
+  ]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -9,16 +9,26 @@
   "minEngineVersion": "0.73.0",
   "required_secrets": [
     {
-      "name": "AWS_ACCESS_KEY_ID",
-      "sensitive": true,
-      "description": "AWS access key ID. For credentials.type: env or static; profile/role_arn deployments may skip. Referenced as ${AWS_ACCESS_KEY_ID} in the iac.provider/aws config.",
-      "prompt": "AWS access key ID"
-    },
-    {
       "name": "AWS_SECRET_ACCESS_KEY",
       "sensitive": true,
       "description": "AWS secret access key (pairs with AWS_ACCESS_KEY_ID). Referenced as ${AWS_SECRET_ACCESS_KEY}.",
       "prompt": "AWS secret access key"
+    }
+  ],
+  "required_config": [
+    {
+      "name": "AWS_REGION",
+      "key": "region",
+      "sensitive": false,
+      "description": "AWS region for provider operations and config templates. Referenced as ${AWS_REGION}.",
+      "prompt": "AWS region"
+    },
+    {
+      "name": "AWS_ACCESS_KEY_ID",
+      "key": "access_key_id",
+      "sensitive": false,
+      "description": "AWS access key ID. For credentials.type: env or static; profile/role_arn deployments may skip. Referenced as ${AWS_ACCESS_KEY_ID}.",
+      "prompt": "AWS access key ID"
     }
   ],
   "iacServices": [
@@ -110,10 +120,9 @@
         "provider": "gitlab",
         "scopes": [
           "project",
-          "group",
-          "env"
+          "group"
         ],
-        "description": "Stored as GitLab CI/CD variables when workflows run on GitLab."
+        "description": "Stored as GitLab CI/CD variables when workflows run on GitLab; variables may also be narrowed with GitLab environment_scope."
       },
       {
         "provider": "vault",
@@ -143,5 +152,38 @@
         ],
         "description": "Provided by the local process environment."
       }
-    ]
+    ],
+  "config_targets": [
+    {
+      "provider": "github",
+      "scopes": [
+        "repo",
+        "env",
+        "org"
+      ],
+      "description": "Stored as GitHub Actions variables when workflows run on GitHub."
+    },
+    {
+      "provider": "gitlab",
+      "scopes": [
+        "project",
+        "group"
+      ],
+      "description": "Stored as GitLab CI/CD variables when workflows run on GitLab; variables may also be narrowed with GitLab environment_scope."
+    },
+    {
+      "provider": "file",
+      "scopes": [
+        "directory"
+      ],
+      "description": "Stored in a local dotenv/config file for local workflows."
+    },
+    {
+      "provider": "env",
+      "scopes": [
+        "process"
+      ],
+      "description": "Provided by the local process environment."
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- move AWS_REGION and AWS_ACCESS_KEY_ID to required_config so wfctl env setup treats them as vars
- keep AWS_SECRET_ACCESS_KEY as a required secret
- correct GitLab target scopes to project/group with environment_scope handled separately

## Validation
- jq empty plugin.json cmd/workflow-plugin-aws/plugin.json
- /tmp/wfctl-env-contract plugin validate -file plugin.json
- /tmp/wfctl-env-contract plugin validate-contract .
- GOWORK=off go test ./...