### PR TITLE
Release locks around AWS provider I/O

### DIFF
--- a/internal/statebackend/s3.go
+++ b/internal/statebackend/s3.go
@@ -339,9 +339,6 @@ func (s *S3IaCStateStore) DeleteState(ctx context.Context, resourceID string) er
 // Lock creates a lock object for resourceID using S3 conditional writes (If-None-Match: *)
 // for atomic, race-free lock acquisition. Fails if the lock already exists.
 func (s *S3IaCStateStore) Lock(ctx context.Context, resourceID string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	key := s.lockKey(resourceID)
 	body := []byte(time.Now().UTC().Format(time.RFC3339))
 	ifNoneMatch := "*"
@@ -364,9 +361,6 @@ func (s *S3IaCStateStore) Lock(ctx context.Context, resourceID string) error {
 
 // Unlock removes the lock object for resourceID.
 func (s *S3IaCStateStore) Unlock(ctx context.Context, resourceID string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	key := s.lockKey(resourceID)
 
 	// Verify lock exists.

--- a/internal/statebackend/s3_lock_test.go
+++ b/internal/statebackend/s3_lock_test.go
@@ -1,0 +1,69 @@
+package statebackend
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+type blockingPutS3Client struct {
+	*mockS3Client
+	entered chan struct{}
+	release chan struct{}
+}
+
+func newBlockingPutS3Client() *blockingPutS3Client {
+	return &blockingPutS3Client{
+		mockS3Client: newMockS3Client(),
+		entered:      make(chan struct{}),
+		release:      make(chan struct{}),
+	}
+}
+
+func (c *blockingPutS3Client) PutObject(ctx context.Context, input *s3.PutObjectInput, opts ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	if aws.ToString(input.Key) == "iac-state/res-1.lock" {
+		close(c.entered)
+		<-c.release
+	}
+	return c.mockS3Client.PutObject(ctx, input, opts...)
+}
+
+func TestS3LockDoesNotBlockDifferentResourceLock(t *testing.T) {
+	client := newBlockingPutS3Client()
+	store := NewS3IaCStateStoreWithClient(client, "test-bucket", "iac-state/")
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- store.Lock(context.Background(), "res-1")
+	}()
+
+	select {
+	case <-client.entered:
+	case <-time.After(time.Second):
+		close(client.release)
+		t.Fatal("first lock did not reach PutObject")
+	}
+
+	otherDone := make(chan error, 1)
+	go func() {
+		otherDone <- store.Lock(context.Background(), "res-2")
+	}()
+
+	select {
+	case err := <-otherDone:
+		if err != nil {
+			t.Fatalf("second lock: %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		close(client.release)
+		t.Fatal("different resource lock blocked behind first lock")
+	}
+
+	close(client.release)
+	if err := <-errCh; err != nil {
+		t.Fatalf("first lock: %v", err)
+	}
+}

--- a/internal/statebackend/s3_lock_test.go
+++ b/internal/statebackend/s3_lock_test.go
@@ -55,9 +55,10 @@ func TestS3LockDoesNotBlockDifferentResourceLock(t *testing.T) {
 	select {
 	case err := <-otherDone:
 		if err != nil {
+			close(client.release)
 			t.Fatalf("second lock: %v", err)
 		}
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(500 * time.Millisecond):
 		close(client.release)
 		t.Fatal("different resource lock blocked behind first lock")
 	}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -388,6 +388,10 @@ func (p *AWSProvider) Status(ctx context.Context, resources []interfaces.Resourc
 
 // DetectDrift compares declared state against live AWS state.
 func (p *AWSProvider) DetectDrift(ctx context.Context, resources []interfaces.ResourceRef) ([]interfaces.DriftResult, error) {
+	if err := p.ensureInitialized(); err != nil {
+		return nil, err
+	}
+
 	var results []interfaces.DriftResult
 	for _, ref := range resources {
 		drv, err := p.initializedResourceDriver(ref.Type)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -236,11 +236,7 @@ func (p *AWSProvider) Capabilities() []interfaces.IaCCapabilityDeclaration {
 func (p *AWSProvider) ResourceDriver(resourceType string) (interfaces.ResourceDriver, error) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-	d, ok := p.driverMap[resourceType]
-	if !ok {
-		return nil, fmt.Errorf("aws: no driver for resource type %q", resourceType)
-	}
-	return d, nil
+	return p.resourceDriver(resourceType)
 }
 
 func stringConfig(raw any) string {
@@ -276,10 +272,8 @@ func stringSliceConfig(raw any) []string {
 
 // Plan computes required create/update/delete actions for the desired state.
 func (p *AWSProvider) Plan(ctx context.Context, desired []interfaces.ResourceSpec, current []interfaces.ResourceState) (*interfaces.IaCPlan, error) {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	if !p.initialized {
-		return nil, fmt.Errorf("aws: provider not initialized")
+	if err := p.ensureInitialized(); err != nil {
+		return nil, err
 	}
 
 	currentMap := make(map[string]*interfaces.ResourceState, len(current))
@@ -302,7 +296,7 @@ func (p *AWSProvider) Plan(ctx context.Context, desired []interfaces.ResourceSpe
 			continue
 		}
 
-		drv, err := p.resourceDriver(spec.Type)
+		drv, err := p.initializedResourceDriver(spec.Type)
 		if err != nil {
 			return nil, err
 		}
@@ -335,15 +329,13 @@ func (p *AWSProvider) Plan(ctx context.Context, desired []interfaces.ResourceSpe
 
 // Destroy deletes a set of resources.
 func (p *AWSProvider) Destroy(ctx context.Context, resources []interfaces.ResourceRef) (*interfaces.DestroyResult, error) {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	if !p.initialized {
-		return nil, fmt.Errorf("aws: provider not initialized")
+	if err := p.ensureInitialized(); err != nil {
+		return nil, err
 	}
 
 	result := &interfaces.DestroyResult{}
 	for _, ref := range resources {
-		drv, err := p.resourceDriver(ref.Type)
+		drv, err := p.initializedResourceDriver(ref.Type)
 		if err != nil {
 			result.Errors = append(result.Errors, interfaces.ActionError{
 				Resource: ref.Name,
@@ -367,15 +359,13 @@ func (p *AWSProvider) Destroy(ctx context.Context, resources []interfaces.Resour
 
 // Status returns the live status of the given resources.
 func (p *AWSProvider) Status(ctx context.Context, resources []interfaces.ResourceRef) ([]interfaces.ResourceStatus, error) {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	if !p.initialized {
-		return nil, fmt.Errorf("aws: provider not initialized")
+	if err := p.ensureInitialized(); err != nil {
+		return nil, err
 	}
 
 	var statuses []interfaces.ResourceStatus
 	for _, ref := range resources {
-		drv, err := p.resourceDriver(ref.Type)
+		drv, err := p.initializedResourceDriver(ref.Type)
 		if err != nil {
 			statuses = append(statuses, interfaces.ResourceStatus{
 				Name:   ref.Name,
@@ -406,15 +396,13 @@ func (p *AWSProvider) Status(ctx context.Context, resources []interfaces.Resourc
 
 // DetectDrift compares declared state against live AWS state.
 func (p *AWSProvider) DetectDrift(ctx context.Context, resources []interfaces.ResourceRef) ([]interfaces.DriftResult, error) {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	if !p.initialized {
-		return nil, fmt.Errorf("aws: provider not initialized")
+	if err := p.ensureInitialized(); err != nil {
+		return nil, err
 	}
 
 	var results []interfaces.DriftResult
 	for _, ref := range resources {
-		drv, err := p.resourceDriver(ref.Type)
+		drv, err := p.initializedResourceDriver(ref.Type)
 		if err != nil {
 			continue
 		}
@@ -439,13 +427,11 @@ func (p *AWSProvider) DetectDrift(ctx context.Context, resources []interfaces.Re
 
 // Import reads an existing AWS resource into a ResourceState.
 func (p *AWSProvider) Import(ctx context.Context, cloudID string, resourceType string) (*interfaces.ResourceState, error) {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	if !p.initialized {
-		return nil, fmt.Errorf("aws: provider not initialized")
+	if err := p.ensureInitialized(); err != nil {
+		return nil, err
 	}
 
-	drv, err := p.resourceDriver(resourceType)
+	drv, err := p.initializedResourceDriver(resourceType)
 	if err != nil {
 		return nil, err
 	}
@@ -505,7 +491,25 @@ func (p *AWSProvider) Close() error {
 	return nil
 }
 
-// resourceDriver is the internal (non-locking) lookup, called within locked sections.
+func (p *AWSProvider) ensureInitialized() error {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if !p.initialized {
+		return fmt.Errorf("aws: provider not initialized")
+	}
+	return nil
+}
+
+func (p *AWSProvider) initializedResourceDriver(resourceType string) (interfaces.ResourceDriver, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if !p.initialized {
+		return nil, fmt.Errorf("aws: provider not initialized")
+	}
+	return p.resourceDriver(resourceType)
+}
+
+// resourceDriver is the internal lookup, called within locked sections.
 func (p *AWSProvider) resourceDriver(resourceType string) (interfaces.ResourceDriver, error) {
 	d, ok := p.driverMap[resourceType]
 	if !ok {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -329,10 +329,6 @@ func (p *AWSProvider) Plan(ctx context.Context, desired []interfaces.ResourceSpe
 
 // Destroy deletes a set of resources.
 func (p *AWSProvider) Destroy(ctx context.Context, resources []interfaces.ResourceRef) (*interfaces.DestroyResult, error) {
-	if err := p.ensureInitialized(); err != nil {
-		return nil, err
-	}
-
 	result := &interfaces.DestroyResult{}
 	for _, ref := range resources {
 		drv, err := p.initializedResourceDriver(ref.Type)
@@ -359,10 +355,6 @@ func (p *AWSProvider) Destroy(ctx context.Context, resources []interfaces.Resour
 
 // Status returns the live status of the given resources.
 func (p *AWSProvider) Status(ctx context.Context, resources []interfaces.ResourceRef) ([]interfaces.ResourceStatus, error) {
-	if err := p.ensureInitialized(); err != nil {
-		return nil, err
-	}
-
 	var statuses []interfaces.ResourceStatus
 	for _, ref := range resources {
 		drv, err := p.initializedResourceDriver(ref.Type)
@@ -396,10 +388,6 @@ func (p *AWSProvider) Status(ctx context.Context, resources []interfaces.Resourc
 
 // DetectDrift compares declared state against live AWS state.
 func (p *AWSProvider) DetectDrift(ctx context.Context, resources []interfaces.ResourceRef) ([]interfaces.DriftResult, error) {
-	if err := p.ensureInitialized(); err != nil {
-		return nil, err
-	}
-
 	var results []interfaces.DriftResult
 	for _, ref := range resources {
 		drv, err := p.initializedResourceDriver(ref.Type)
@@ -427,10 +415,6 @@ func (p *AWSProvider) DetectDrift(ctx context.Context, resources []interfaces.Re
 
 // Import reads an existing AWS resource into a ResourceState.
 func (p *AWSProvider) Import(ctx context.Context, cloudID string, resourceType string) (*interfaces.ResourceState, error) {
-	if err := p.ensureInitialized(); err != nil {
-		return nil, err
-	}
-
 	drv, err := p.initializedResourceDriver(resourceType)
 	if err != nil {
 		return nil, err

--- a/provider/provider_lock_test.go
+++ b/provider/provider_lock_test.go
@@ -73,7 +73,7 @@ func TestAWSProviderStatusDoesNotHoldProviderLockDuringDriverRead(t *testing.T) 
 
 	select {
 	case <-writerDone:
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(500 * time.Millisecond):
 		close(driver.release)
 		t.Fatal("provider writer blocked behind Status driver Read")
 	}

--- a/provider/provider_lock_test.go
+++ b/provider/provider_lock_test.go
@@ -1,0 +1,85 @@
+package provider
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+type blockingReadDriver struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func newBlockingReadDriver() *blockingReadDriver {
+	return &blockingReadDriver{entered: make(chan struct{}), release: make(chan struct{})}
+}
+
+func (d *blockingReadDriver) Create(context.Context, interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	return nil, nil
+}
+func (d *blockingReadDriver) Read(_ context.Context, ref interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
+	close(d.entered)
+	<-d.release
+	return &interfaces.ResourceOutput{Name: ref.Name, Type: ref.Type, ProviderID: ref.ProviderID, Status: "active"}, nil
+}
+func (d *blockingReadDriver) Update(context.Context, interfaces.ResourceRef, interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	return nil, nil
+}
+func (d *blockingReadDriver) Delete(context.Context, interfaces.ResourceRef) error { return nil }
+func (d *blockingReadDriver) Diff(context.Context, interfaces.ResourceSpec, *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {
+	return &interfaces.DiffResult{}, nil
+}
+func (d *blockingReadDriver) HealthCheck(context.Context, interfaces.ResourceRef) (*interfaces.HealthResult, error) {
+	return &interfaces.HealthResult{Healthy: true}, nil
+}
+func (d *blockingReadDriver) Scale(context.Context, interfaces.ResourceRef, int) (*interfaces.ResourceOutput, error) {
+	return nil, nil
+}
+func (d *blockingReadDriver) SensitiveKeys() []string { return nil }
+
+func TestAWSProviderStatusDoesNotHoldProviderLockDuringDriverRead(t *testing.T) {
+	driver := newBlockingReadDriver()
+	p := &AWSProvider{
+		initialized: true,
+		driverMap: map[string]interfaces.ResourceDriver{
+			"infra.test": driver,
+		},
+	}
+
+	statusDone := make(chan error, 1)
+	go func() {
+		_, err := p.Status(context.Background(), []interfaces.ResourceRef{{
+			Name: "resource-1", Type: "infra.test", ProviderID: "provider-1",
+		}})
+		statusDone <- err
+	}()
+
+	select {
+	case <-driver.entered:
+	case <-time.After(time.Second):
+		close(driver.release)
+		t.Fatal("Status did not reach driver Read")
+	}
+
+	writerDone := make(chan struct{})
+	go func() {
+		p.mu.Lock()
+		p.mu.Unlock()
+		close(writerDone)
+	}()
+
+	select {
+	case <-writerDone:
+	case <-time.After(100 * time.Millisecond):
+		close(driver.release)
+		t.Fatal("provider writer blocked behind Status driver Read")
+	}
+
+	close(driver.release)
+	if err := <-statusDone; err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- remove process mutex serialization around S3 state lock/unlock calls
- initialize and snapshot AWS resource drivers without holding provider mu through cloud operations
- add starvation regressions for S3 locks and provider operations

## Verification
- go test ./...
- go test -race ./internal/statebackend ./provider -run 'Test.*DoesNotBlock|Test.*DoesNotStarve|TestProvider' -count=1
- revert proof: focused regression tests fail when old lock-across-I/O behavior is restored

## Downstream impact
No module contract change. After merge and release, bump workflow-registry workflow-plugin-aws from v2.3.5. Runtime consumers found in workflow-registry and workflow-scenarios IaC scenarios using AWS iac.provider/state.

Refs GoCodeAlone/workspace#133
